### PR TITLE
Fix mistake in Infinity Dimension help page (#3474)

### DIFF
--- a/src/core/secret-formula/h2p.js
+++ b/src/core/secret-formula/h2p.js
@@ -580,7 +580,7 @@ applied depends on which Infinity Dimension you purchase. <!-- Sorry Garnet :/ -
 <br>
 <br>
 <b>Infinity Dimension Production:</b> Just like Antimatter Dimensions, each Infinity Dimension produces the
-next highest Infinity Dimension.
+next lower Infinity Dimension.
 <br>
 <br>
 Every crunch, your produced Infinity Dimensions are reset to the amount you purchased. While the production


### PR DESCRIPTION
Infinity dimensions produce the next *lower* dimension, not the next higher (just like Antimatter Dimensions)